### PR TITLE
Bumped version.xml to 1.4.0-1

### DIFF
--- a/version.xml
+++ b/version.xml
@@ -12,8 +12,8 @@
 <version>
 	<application>formHoneypot</application>
 	<type>plugins.generic</type>
-	<release>1.4.0.0</release>
-	<date>2020-05-11</date>
+	<release>1.4.0.1</release>
+	<date>2021-12-08</date>
 	<sitewide>1</sitewide>
 	<lazy-load>1</lazy-load>
 	<class>FormHoneypotPlugin</class>


### PR DESCRIPTION
Currently, when having 1.4.0.0 installed in OJS, it does not recognize that there is a new release (1.4.0-1). Hopefully, this modifications fix this behavior.